### PR TITLE
图标文件规范支持动态图片

### DIFF
--- a/unstable/图标文件规范.md
+++ b/unstable/图标文件规范.md
@@ -3,8 +3,8 @@
 > __警告！此规范内容是不稳定版本，可能会发生破坏兼容性的更新。当无法保障向下兼容时，将会升级此文档的主版本号，如从“1.0”更新到“2.0”。反之，普通更新只会升级次版本号，如“1.0”更新到“1.1”，其对“1.0”版本向下兼容。请在使用前确认此文档的版本号，并为将来可能发生的兼容性变化做好准备。__
 
 * 维护者：zccrs zhangjide@uniontech.com
-* 版本：1.0
-* 修改日期：2021.8.16
+* 版本：1.1
+* 修改日期：2022.11.21
 * 议题：#5
 
 ## 引言
@@ -109,6 +109,157 @@ dci 使用小端序，文件的元数据位于文件开头。内容如下：
 * pressed：点击后且未释放时的状态
 
 > 当图标只提供 `normal` 状态的文件时，可使用一些固定规则对 `normal` 状态进行加工而得到其它状态，此规范不约束加工后的效果。
+
+### 图标动画
+
+如果对应状态的图片文件具有动画效果，如嵌入了动态的 webp 图片，则应当在图标状态变化时播放动画。动画播放需满足以下规则：
+
+1. 初始化状态不自动播放动画，初始为 normal 状态时显示动画第一帧，其它状态显示动画的最后一帧；
+2. normal 状态动态图的第一帧和最后一帧要等价，即内容完全相同；
+3. 当从 normal 状态变为 hover 状态时，使用 1.0 倍速正序播放 hover 图片的动画，且停留到最后一帧；
+4. 当从 hover 状态变为 pressed 状态时，使用 1.0 倍速正序播放 pressed 图片的动画，且停留到最后一帧；
+5. 当从 normal 状态变为 pressed 状态时，如果存在 hover 状态，则界面效果（仅影响UI，不实际改变图标的当前状态）先变化为 hover 状态，再由 hover 状态变化为 pressed 状态，在此期间的动画使用 2.0（如果 hover 状态是静态图片，则使用 1.0 倍速）倍速正序播放，不同动画图片切换时中间无停顿。否则，如果 hover 状态不存在，则直接使用 1.0 倍速正序播放 pressed 图片的动画。动画播放完毕后停留到最后一帧；
+6. 当从 hover 状态变为 normal 状态时，使用 1.0 倍速倒序播放 hover 图片动画，不停留到最后一帧，动画播放完毕后当作初始化状态停留到 normal 状态的图片；
+7. 当从 pressed 状态变为 hover 状态时，使用 1.0 倍速倒序播放 pressed 图片动画，不停留到最后一帧，动画播放完毕后当作初始化状态停留到 hover 状态的图片；
+8. 当从 pressed 状态变为 normal 状态时，如果存在 hover 状态，则界面效果（仅影响UI，不实际改变图标的当前状态）先变化为 hover 状态，再由 hover 状态变化为 normal，在此期间的动画使用 2.0（如果 hover 状态是静态图片，则使用 1.0 倍速）倍速倒序播放，不同动画图片切换时中间无停顿。否则，如果 hover 状态不存在，则直接使用 1.0 倍速倒序播放 pressed 图片的动画。动画播放完毕后当作初始化状态停留到 normal 状态的图片；
+9.  当从任意状态变为 disabled 状态时，界面效果（仅影响UI，不实际改变图标的当前状态）先变为（直接变化，不播放任何动画）初始化时的 normal 状态，再使用 1.0 倍速正序播放 disabled 图片的动画，动画播放完毕后停留到最后一帧；
+10. 当从 disabled 状态变为任意状态时，使用 1.0 倍速倒序播放 disabled 图片的动画，最后停留在 normal 状态（仅影响UI，不实际改变图标的当前状态）对应的图片；
+11. 只有最后一个播放的动画允许循环播放，如从 normal 状态变为 pressed 状态，顺序播放 hover 和 pressed 对应的动画时，hover 的动画不允许循环播放；
+12. 当需要播放动画时，如果当前已经有动画正在播放，如果待播放的动画是当前动画的逆播放，则暂停当前动画，且从暂停的帧开始倒序播放。否则如果待播放的动画是当前动画的延续（即可以衔接到一起，如从 normal 状态变为 hover 状态，在播放动画期间又变为了 pressed 状态），则等到当前动画播放完毕后接着播放新动画，且当前动画禁止重复播放。除此之外的情况则停止当前动画，立即开始播放新动画；
+13. normal 状态的动画用于需要突显此图标的情况，由使用方决定在合适的时机播放。一些使用场景：某个图标刚被新增到某个地方显示时可以播放 normal 的动画，比如新安装一个应用，这个应用的图标出现在 Launcher 上时，或者是把一个应用图标发送到 Dock 或 Desktop 上面时；当一个应用最小化到任务栏时，任务栏上可以播放 normal 状态的动画。
+
+伪代码实现：
+
+````
+enum Flags {
+    Continue = 1,
+    InvertedOrder = 2,
+    IgnoreLastImageLoop = 4,
+    AllowNonLastImageLoop = 8
+};
+
+fn playImages(images, speed, flags)
+{
+...
+}
+
+fn playAnimation(oldMode, newMode)
+{
+    if (oldMode == Normal) {
+        if (newMode == Normal) {
+            showImage(Normal);
+        } else if (newMode == Hover) {
+            if (hover.supportsAnimation()) {
+                playImages({hover}, 1.0);
+            } else {
+                showImage(Hover);
+            }
+        } else if (newMode == Pressed) {
+            if (pressed.supportsAnimation()) {
+                if (hover.supportsAnimation()) {
+                    playImages({hover, pressed}, 2.0);
+                } else {
+                    playImages({pressed}, 1.0);
+                }
+            } else {
+                showImage(Pressed);
+            }
+        } else if (newMode == Disabled) {
+            if (disabled.supportsAnimation()) {
+                playImages({disabled}, 1.0, Flags::IgnoreLastImageLoop);
+            } else {
+                showImage(Disabled);
+            }
+        }
+    } else if (oldMode == Hover) {
+        if (newMode == Normal) {
+            if (hover.supportsAnimation()) {
+                setFinishedImage(Normal);
+                playImages({hover}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
+            } else {
+                showImage(Normal);
+            }
+        } else if (newMode == Pressed) {
+            if (pressed.isNull()) {
+                if (hover.supportsAnimation()) {
+                    playImages({hover}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
+                } else {
+                    showImage(Normal);
+                }
+                return;
+            }
+
+            if (pressed.supportsAnimation()) {
+                playImages({pressed}, 1.0);
+            } else {
+                showImage(Pressed);
+            }
+        } else if (newMode == Disabled) {
+            if (disabled.isNull()) {
+                showImage(Normal);
+                return;
+            }
+
+            if (disabled.supportsAnimation()) {
+                playImages({disabled}, 1.0, Flags::IgnoreLastImageLoop);
+            } else {
+                showImage(Disabled);
+            }
+        }
+    } else if (oldMode == Pressed) {
+        if (newMode == Normal) {
+            if (!pressed.supportsAnimation()) {
+                showImage(Normal);
+                return false;
+            }
+
+            setFinishedImage(Normal);
+            if (hover.supportsAnimation()) {
+                playImages({hover, pressed}, 2.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
+            } else {
+                playImages({pressed}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
+            }
+        } else if (newMode == Hover) {
+            if (pressed.isNull()) {
+                if (hover.supportsAnimation()) {
+                    playImages({hover}, 1.0);
+                } else {
+                    showImage(Hover);
+                }
+                return;
+            }
+
+            if (pressed.supportsAnimation()) {
+                ensureHoverModeLastImage();
+                finishedImage = hoverModeLastImage;
+                playImages({pressed}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
+            } else {
+                showImage(Hover);
+            }
+        } else if (newMode == Disabled) {
+            if (disabled.isNull()) {
+                showImage(Normal);
+                return;
+            }
+
+            if (disabled.supportsAnimation()) {
+                playImages({disabled}, 1.0, Flags::IgnoreLastImageLoop);
+            } else {
+                showImage(Disabled);
+            }
+        }
+    } else if (oldMode == Disabled) {
+        if (disabled.supportsAnimation()) {
+            setFinishedImage(Normal);
+            playImages({disabled}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
+        } else {
+            showImage(Normal);
+        }
+    }
+
+    return;
+}
+````
 
 ### 缩放倍数
 


### PR DESCRIPTION
### 图标动画

如果对应状态的图片文件具有动画效果，如嵌入了动态的 webp 图片，则应当在图标状态变化时播放动画。动画播放需满足以下规则：

1. 初始化状态不自动播放动画，初始为 normal 状态时显示动画第一帧，其它状态显示动画的最后一帧；
2. normal 状态动态图的第一帧和最后一帧要等价，即内容完全相同；
3. 当从 normal 状态变为 hover 状态时，使用 1.0 倍速正序播放 hover 图片的动画，且停留到最后一帧；
4. 当从 hover 状态变为 pressed 状态时，使用 1.0 倍速正序播放 pressed 图片的动画，且停留到最后一帧；
5. 当从 normal 状态变为 pressed 状态时，如果存在 hover 状态，则界面效果（仅影响UI，不实际改变图标的当前状态）先变化为 hover 状态，再由 hover 状态变化为 pressed 状态，在此期间的动画使用 2.0（如果 hover 状态是静态图片，则使用 1.0 倍速）倍速正序播放，不同动画图片切换时中间无停顿。否则，如果 hover 状态不存在，则直接使用 1.0 倍速正序播放 pressed 图片的动画。动画播放完毕后停留到最后一帧；
6. 当从 hover 状态变为 normal 状态时，使用 1.0 倍速倒序播放 hover 图片动画，不停留到最后一帧，动画播放完毕后当作初始化状态停留到 normal 状态的图片；
7. 当从 pressed 状态变为 hover 状态时，使用 1.0 倍速倒序播放 pressed 图片动画，不停留到最后一帧，动画播放完毕后当作初始化状态停留到 hover 状态的图片；
8. 当从 pressed 状态变为 normal 状态时，如果存在 hover 状态，则界面效果（仅影响UI，不实际改变图标的当前状态）先变化为 hover 状态，再由 hover 状态变化为 normal，在此期间的动画使用 2.0（如果 hover 状态是静态图片，则使用 1.0 倍速）倍速倒序播放，不同动画图片切换时中间无停顿。否则，如果 hover 状态不存在，则直接使用 1.0 倍速倒序播放 pressed 图片的动画。动画播放完毕后当作初始化状态停留到 normal 状态的图片；
9.  当从任意状态变为 disabled 状态时，界面效果（仅影响UI，不实际改变图标的当前状态）先变为（直接变化，不播放任何动画）初始化时的 normal 状态，再使用 1.0 倍速正序播放 disabled 图片的动画，动画播放完毕后停留到最后一帧；
10. 当从 disabled 状态变为任意状态时，使用 1.0 倍速倒序播放 disabled 图片的动画，最后停留在 normal 状态（仅影响UI，不实际改变图标的当前状态）对应的图片；
11. 只有最后一个播放的动画允许循环播放，如从 normal 状态变为 pressed 状态，顺序播放 hover 和 pressed 对应的动画时，hover 的动画不允许循环播放；
12. 当需要播放动画时，如果当前已经有动画正在播放，如果待播放的动画是当前动画的逆播放，则暂停当前动画，且从暂停的帧开始倒序播放。否则如果待播放的动画是当前动画的延续（即可以衔接到一起，如从 normal 状态变为 hover 状态，在播放动画期间又变为了 pressed 状态），则等到当前动画播放完毕后接着播放新动画，且当前动画禁止重复播放。除此之外的情况则停止当前动画，立即开始播放新动画；
13. normal 状态的动画用于需要突显此图标的情况，由使用方决定在合适的时机播放。一些使用场景：某个图标刚被新增到某个地方显示时可以播放 normal 的动画，比如新安装一个应用，这个应用的图标出现在 Launcher 上时，或者是把一个应用图标发送到 Dock 或 Desktop 上面时；当一个应用最小化到任务栏时，任务栏上可以播放 normal 状态的动画。

伪代码实现：

````
enum Flags {
    Continue = 1,
    InvertedOrder = 2,
    IgnoreLastImageLoop = 4,
    AllowNonLastImageLoop = 8
};

fn playImages(images, speed, flags)
{
...
}

fn playAnimation(oldMode, newMode)
{
    if (oldMode == Normal) {
        if (newMode == Normal) {
            showImage(Normal);
        } else if (newMode == Hover) {
            if (hover.supportsAnimation()) {
                playImages({hover}, 1.0);
            } else {
                showImage(Hover);
            }
        } else if (newMode == Pressed) {
            if (pressed.supportsAnimation()) {
                if (hover.supportsAnimation()) {
                    playImages({hover, pressed}, 2.0);
                } else {
                    playImages({pressed}, 1.0);
                }
            } else {
                showImage(Pressed);
            }
        } else if (newMode == Disabled) {
            if (disabled.supportsAnimation()) {
                playImages({disabled}, 1.0, Flags::IgnoreLastImageLoop);
            } else {
                showImage(Disabled);
            }
        }
    } else if (oldMode == Hover) {
        if (newMode == Normal) {
            if (hover.supportsAnimation()) {
                setFinishedImage(Normal);
                playImages({hover}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
            } else {
                showImage(Normal);
            }
        } else if (newMode == Pressed) {
            if (pressed.isNull()) {
                if (hover.supportsAnimation()) {
                    playImages({hover}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
                } else {
                    showImage(Normal);
                }
                return;
            }

            if (pressed.supportsAnimation()) {
                playImages({pressed}, 1.0);
            } else {
                showImage(Pressed);
            }
        } else if (newMode == Disabled) {
            if (disabled.isNull()) {
                showImage(Normal);
                return;
            }

            if (disabled.supportsAnimation()) {
                playImages({disabled}, 1.0, Flags::IgnoreLastImageLoop);
            } else {
                showImage(Disabled);
            }
        }
    } else if (oldMode == Pressed) {
        if (newMode == Normal) {
            if (!pressed.supportsAnimation()) {
                showImage(Normal);
                return false;
            }

            setFinishedImage(Normal);
            if (hover.supportsAnimation()) {
                playImages({hover, pressed}, 2.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
            } else {
                playImages({pressed}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
            }
        } else if (newMode == Hover) {
            if (pressed.isNull()) {
                if (hover.supportsAnimation()) {
                    playImages({hover}, 1.0);
                } else {
                    showImage(Hover);
                }
                return;
            }

            if (pressed.supportsAnimation()) {
                ensureHoverModeLastImage();
                finishedImage = hoverModeLastImage;
                playImages({pressed}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
            } else {
                showImage(Hover);
            }
        } else if (newMode == Disabled) {
            if (disabled.isNull()) {
                showImage(Normal);
                return;
            }

            if (disabled.supportsAnimation()) {
                playImages({disabled}, 1.0, Flags::IgnoreLastImageLoop);
            } else {
                showImage(Disabled);
            }
        }
    } else if (oldMode == Disabled) {
        if (disabled.supportsAnimation()) {
            setFinishedImage(Normal);
            playImages({disabled}, 1.0, Flags::InvertedOrder | Flags::IgnoreLastImageLoop);
        } else {
            showImage(Normal);
        }
    }

    return;
}
````
